### PR TITLE
Sanitize output paths

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.0.3: QmQine7gvHncNevKtG9QXxf3nXcwSj6aDDmMm52mHofEEp
+0.1.0: QmTkC7aeyDyjfdMTCVcG9P485TMJd6foLaLbf11DZ5WrnV

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
   "license": "MIT",
   "name": "tar-utils",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.0.3"
+  "version": "0.1.0"
 }
 

--- a/sanitize.go
+++ b/sanitize.go
@@ -1,0 +1,19 @@
+// +build !windows
+
+package tar
+
+import (
+	"os"
+)
+
+func isNullDevice(path string) bool {
+	return path == os.DevNull
+}
+
+func sanitizePath(path string) (string, error) {
+	return path, nil
+}
+
+func platformLink(inLink Link) error {
+	return nil
+}

--- a/sanitize_windows.go
+++ b/sanitize_windows.go
@@ -1,0 +1,83 @@
+package tar
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+//https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx
+var reservedNames = [...]string{"CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"}
+var reservedCharsRegex *regexp.Regexp
+
+const reservedCharsStr = `[<>:"\\|?*]`                    //NOTE: `/` is not included as it is our standard path separator
+const reservedNamesRegexFmt = `(?i)^(%s)(?: *%s*)?[^\w ]` // $reservedName, $reservedCharsStr
+
+func init() {
+	reservedCharsRegex = regexp.MustCompile(reservedCharsStr)
+}
+
+func isNullDevice(path string) bool {
+	if len(path) != 3 {
+		return false
+	}
+	if path[0]|0x20 != 'n' {
+		return false
+	}
+	if path[1]|0x20 != 'u' {
+		return false
+	}
+	if path[2]|0x20 != 'l' {
+		return false
+	}
+	return true
+}
+
+func sanitizePath(path string) (string, error) {
+	pathElements := strings.Split(path, "/")
+
+	//first pass: strip illegal tail & prefix reserved names `CON .` -> `_CON`
+	for pi := range pathElements {
+		pathElements[pi] = strings.TrimRight(pathElements[pi], ". ") //MSDN: Do not end a file or directory name with a space or a period
+
+		for _, rn := range reservedNames {
+			re, _ := regexp.Compile(fmt.Sprintf(reservedNamesRegexFmt, rn, reservedCharsStr)) //no err, regex is a constant with guaranteed constant arguments
+			if matched := re.MatchString(pathElements[pi]); matched {
+				pathElements[pi] = "_" + pathElements[pi]
+				break
+			}
+		}
+	}
+
+	//second pass: scan and encode reserved characters ? -> %3F
+	res := strings.Join(pathElements, `/`) //intentionally avoiding [file]path.Clean() being called with Join(); we do our own filtering first
+	illegalIndices := reservedCharsRegex.FindAllStringIndex(res, -1)
+
+	if illegalIndices != nil {
+		var lastIndex int
+		var builder strings.Builder
+		allocAssist := (len(res) - len(illegalIndices)) + (len(illegalIndices) * 3) //3 = encoded length
+		builder.Grow(allocAssist)
+
+		for _, si := range illegalIndices {
+			builder.WriteString(res[lastIndex:si[0]])              //append up to problem char
+			builder.WriteString(url.QueryEscape(res[si[0]:si[1]])) //escape and append problem char
+			lastIndex = si[1]
+		}
+		builder.WriteString(res[lastIndex:]) //append remainder
+		res = builder.String()
+	}
+
+	return filepath.FromSlash(res), nil
+}
+
+func platformLink(inLink Link) error {
+	if strings.HasPrefix(inLink.Target, string(os.PathSeparator)) || strings.HasPrefix(inLink.Target, "/") {
+		return fmt.Errorf("Link target %q is relative to drive root (forbidden)", inLink.Target)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This allows paths inside of an archive to be extracted even if their target-path would otherwise be illegal.

TODO:
~~`^` is allowed on Windows/NTFS but not Windows/FAT32, accounting for this will require detecting the target FS and switching censor-sets.~~ This isn't true, I can create files with `^` in the filename on FAT, FAT32, and NTFS on Windows.

I'm waiting for something upstream in order to handle `NUL` directory output, it's either going to be fixed upstream or handled specifically here.