### PR TITLE
bump to make the hash resolvable

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.0.2: QmYk64JEF4QWPB9Kqib63g8vfYfv78AmSUyeFaMaX6F9vQ
+0.0.3: QmQine7gvHncNevKtG9QXxf3nXcwSj6aDDmMm52mHofEEp

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
   "license": "MIT",
   "name": "tar-utils",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.0.2"
+  "version": "0.0.3"
 }
 


### PR DESCRIPTION
1. `gx publish -f` on a clean checkout of the last version produced a different hash.
2. Nobody (not even the gateway) could find the last version.